### PR TITLE
Fixed fishing and woodcutting animation ID's to the correct ones

### DIFF
--- a/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
+++ b/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
@@ -3,7 +3,7 @@ package com.jonnesaloranta.enums;
 public class PlayerAnim {
 
     public static final int ANIM_MINING = 7139;
-    public static final int ANIM_WOODCUTTING = 867;
+    public static final int ANIM_WOODCUTTING = 2846;
     public static final int ANIM_WOODCUTTING_FELLING_AXE = 10071;
-    public static final int ANIM_FISHING = 618;
+    public static final int ANIM_FISHING = 7401;
 }


### PR DESCRIPTION
Updated animation ID's. This should fix #1 affecting fishing and woodcutting.