### PR TITLE
Added more boostable situations

### DIFF
--- a/src/main/java/com/jonnesaloranta/SkillingBoostReminderPlugin.java
+++ b/src/main/java/com/jonnesaloranta/SkillingBoostReminderPlugin.java
@@ -105,6 +105,12 @@ public class SkillingBoostReminderPlugin extends Plugin {
 				isSkilling = config.mining();
 				break;
 			case PlayerAnim.ANIM_FISHING:
+			case PlayerAnim.ANIM_FISHING_1:
+			case PlayerAnim.ANIM_FISHING_2:
+			case PlayerAnim.ANIM_FISHING_3:
+			case PlayerAnim.ANIM_FISHING_4:
+			case PlayerAnim.ANIM_FISHING_5:
+			case PlayerAnim.ANIM_FISHING_6:
 				isSkilling = config.fishing();
 				break;
 			case PlayerAnim.ANIM_WOODCUTTING:

--- a/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
+++ b/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
@@ -5,7 +5,7 @@ public class PlayerAnim {
     public static final int ANIM_MINING = 7139;
     public static final int ANIM_WOODCUTTING = 2846;
     public static final int ANIM_WOODCUTTING_FELLING_AXE = 10071;
-    public static final int ANIM_FISHING = 7401; // dragon notification
+    public static final int ANIM_FISHING = 7401; // dragon harpoon
     public static final int ANIM_FISHING_1 = 618; // regular harpoon
     public static final int ANIM_FISHING_2 = 619; // lobster pot
     public static final int ANIM_FISHING_3 = 620; // big net

--- a/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
+++ b/src/main/java/com/jonnesaloranta/enums/PlayerAnim.java
@@ -5,5 +5,12 @@ public class PlayerAnim {
     public static final int ANIM_MINING = 7139;
     public static final int ANIM_WOODCUTTING = 2846;
     public static final int ANIM_WOODCUTTING_FELLING_AXE = 10071;
-    public static final int ANIM_FISHING = 7401;
+    public static final int ANIM_FISHING = 7401; // dragon notification
+    public static final int ANIM_FISHING_1 = 618; // regular harpoon
+    public static final int ANIM_FISHING_2 = 619; // lobster pot
+    public static final int ANIM_FISHING_3 = 620; // big net
+    public static final int ANIM_FISHING_4 = 621; // small net
+    public static final int ANIM_FISHING_5 = 622; // normal rod (swing)
+    public static final int ANIM_FISHING_6 = 623; // normal rod (fishing)
+
 }


### PR DESCRIPTION
Added checks for situations where a player can hold a dragon harpoon etc. but doesn't actually use it for fishing.
Now boosting notification should work with, fishing rods(e.g barbarian fishing, lava eels), fishing nets and lobster cage(dark crabs etc).